### PR TITLE
Add text about appropriate values of light threshold

### DIFF
--- a/TAGS_shiny/app.R
+++ b/TAGS_shiny/app.R
@@ -83,6 +83,7 @@ sidebarLayout(
                    actionButton("calculate", "Calculate sun angle from data"),
                    br(),
                    h3("Step 3. Light threshold entry"),
+                   p("Be sure to enter a value within the range of your data. For example, if the values of light in your dataset range from 40 to 200, you will need to increase the light threshold to a value between 40 and 200"),
                    #Enter a value for light threshold to calculate sunrise/sunset.
                    numericInput("light_threshold", 
                                 h4("Light threshold"), 


### PR DESCRIPTION
# Summary

This PR adds some text to the app to help users avoid the errors caused by inappropriate light threshold values. 

## Description

If users attempt to upload a file with light values that have a range excluding the default value of light threshold, an error message is displayed in place of the graph (see below). e.g. if the uploaded dataset has light values ranging between 40 and 200, the app throws an error with the default light threshold value of 5.5. The error is thrown from line 12 of source_iPreselection.R. This ultimately stems from `i.twilightEvents()` identifying 0 rows as twilight events (I think this is because all conditions on lines 5-7 of source_iTwilightEvents.R evaluate to FALSE). Additional error handling or automatically updating the value of light threshold based on uploaded data could be considered.

## Error messages

When running locally: "Error: arguments imply differing number of rows: 2, 0"
When running on shinyapps.io: "Error: An error has occurred. Check your logs or contact the app author for clarification."